### PR TITLE
Exclude some paths from .git folder removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The `extras > cleanup-vcs-dirs > exclude` directory path can be a string or an a
  * `["some/directory", "another/directory"]`
  * `"/some\\/special\\/dir/"`
 
-   (Note that any backslash characters in a regex string need to be escaped with an extra backslash when used in a JSON file like composer.json. In other words, PHP's `'/custom\/*/'` becomes `"/custom\\*/"` in JSON.)
+   (Note that any backslash characters in a regex string need to be escaped with an extra backslash when used in a JSON file like composer.json. In other words, PHP's `'/custom\/*/'` becomes `"/custom\\/*/"` in JSON.)
 
 After adding an `extras > cleanup-vcs-dirs > exclude` entry, you will need to run `composer reinstall --prefer-source [package-needing-git]` to force composer to re-add the .git folder.
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,39 @@ While not a best practice, sometimes it's simply a requirement.
 ## How to use the plugin
 
 When required in composer.json, the plugin will automatically
-search for any .git directories in installed or updated 
+search for any .git directories in installed or updated
 dependencies and delete them immediately.
 
 There's nothing else you need to do after requiring this plugin
 in your main composer.json file.
+
+Optionally, if you wish to develop on one of your project's dependencies and keep its .git folder, you can tell composer-cleanup-vcs-dirs to exclude that dependency's path from deletion. In your project's composer.json, set the `extras > cleanup-vcs-dirs > exclude` entry with a pattern that matches the dependency installation directories you wish to keep the .git folder for. For example, the following would keep .git folders located in a `custom` folder and inside the `symfony/debug` folder:
+
+```json
+{
+    "name": "my-project",
+    "description": "This is the composer.json file",
+    "type": "project",
+    "extra": {
+        "cleanup-vcs-dirs": {
+            "exclude": [
+                "symfony/debug",
+                "/custom\\/*/"
+            ]
+        }
+    }
+}
+```
+
+The `extras > cleanup-vcs-dirs > exclude` directory path can be a string or an array of strings. You can use patterns (delimited with `/` sign) or simple strings.
+
+ * `"some/special/dir"`
+ * `["some/directory", "another/directory"]`
+ * `"/some\\/special\\/dir/"`
+
+   (Note that any backslash characters in a regex string need to be escaped with an extra backslash when used in a JSON file like composer.json. In other words, PHP's `'/custom\/*/'` becomes `"/custom\\*/"` in JSON.)
+
+After adding an `extras > cleanup-vcs-dirs > exclude` entry, you will need to run `composer reinstall --prefer-source [package-needing-git]` to force composer to re-add the .git folder.
 
 ## Running the command directly
 

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -46,14 +46,24 @@ class Handler {
 
     $iterator = $finder
       ->directories()
-      ->in($parentDir)
+      ->in($excludeRoot ? $parentDir : './')
       ->ignoreVCS(false)
       ->ignoreDotFiles(false)
       ->exclude(['node_modules', '.git/*'])
       ->name('.git');
 
     if ($excludeRoot) {
-      $iterator = $iterator->depth('> 0');
+      $iterator->depth('> 0');
+    }
+    else {
+      $iterator->path($parentDir);
+    }
+
+    $extra = $this->composer->getPackage()->getExtra();
+    if (isset($extra['cleanup-vcs-dirs']) && !empty($extra['cleanup-vcs-dirs']['exclude'])) {
+      foreach ((array) $extra['cleanup-vcs-dirs']['exclude'] as $pattern) {
+        $iterator->notPath($pattern);
+      }
     }
 
     return $iterator;


### PR DESCRIPTION
Sometimes, you want to develop one or more of the composer dependencies while they are installed inside your project. Normally, this plugin deletes all dependencies' .git folders. This PR adds an "exclude" feature that allows you to exclude some .git folders from this plugin's deletion.

The "exclude" paths entry is an array of regex patterns that are consumed by [Symfony's Finder](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Finder/Finder.php#L267) ([docs](https://symfony.com/doc/current/components/finder.html#path))

The docs on how to use this feature are in the [README](https://github.com/VolantisDev/composer-cleanup-vcs-dirs/blob/623c5c362a7f0e02d719f2af9c92c1c8d29cbc51/README.md#how-to-use-the-plugin).