### PR TITLE
fix: execute needs to return an int

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -12,10 +12,11 @@ class Command extends BaseCommand
     $this->setName('cleanup-vcs-dirs');
   }
 
-  protected function execute(InputInterface $input, OutputInterface $output) {
+  protected function execute(InputInterface $input, OutputInterface $output):int {
     $output->writeln('<info>Removing all child .git directories under the project directory</info>');
 
     $handler = new Handler($this->getComposer(), $this->getIO());
     $handler->cleanupVcsDirs(getcwd(), true);
+    return 0;
   }
 }


### PR DESCRIPTION
Since symfony 7.2 return signature have been converted to native format and enforced by the php interpreter: https://github.com/symfony/console/commit/8b83b2fc425bd48e3e4e863da3a1c8f74d9dac91 This fix simple add the correct signature and return 0.